### PR TITLE
Refactor, interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# BTCPay Server Greenfield API PHP client library
+

--- a/examples/basic_usage.php
+++ b/examples/basic_usage.php
@@ -1,0 +1,20 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use BTCPayServer\Client\Store;
+
+// Fill in with your BTCPay Server data.
+$apiKey = '';
+$host = ''; // e.g. https://your.btcpay-server.tld
+$storeId = '';
+$invoiceId = '';
+
+// Get information about store on BTCPay Server.
+try {
+  $client = new Store($host, $apiKey);
+  var_dump($client->getStore($storeId));
+}
+catch (\Exception $e) {
+  echo "Error: " . $e->getMessage();
+}

--- a/examples/basic_usage.php
+++ b/examples/basic_usage.php
@@ -15,6 +15,6 @@ try {
   $client = new Store($host, $apiKey);
   var_dump($client->getStore($storeId));
 }
-catch (\Exception $e) {
+catch (\Throwable $e) {
   echo "Error: " . $e->getMessage();
 }

--- a/examples/get_invoice.php
+++ b/examples/get_invoice.php
@@ -1,0 +1,22 @@
+<?php
+
+// Include autoload file.
+require __DIR__ . '/../vendor/autoload.php';
+
+// Import Invoice client class.
+use BTCPayServer\Client\Invoice;
+
+// Fill in with your BTCPay Server data.
+$apiKey = '';
+$host = ''; // e.g. https://your.btcpay-server.tld
+$storeId = '';
+$invoiceId = '';
+
+// Get information about a specific invoice.
+try {
+  $client = new Invoice($host, $apiKey);
+  var_dump($client->getInvoice($storeId, $invoiceId));
+}
+catch (\Exception $e) {
+  echo "Error: " . $e->getMessage();
+}

--- a/examples/get_invoice.php
+++ b/examples/get_invoice.php
@@ -17,6 +17,6 @@ try {
   $client = new Invoice($host, $apiKey);
   var_dump($client->getInvoice($storeId, $invoiceId));
 }
-catch (\Exception $e) {
+catch (\Throwable $e) {
   echo "Error: " . $e->getMessage();
 }

--- a/src/Client/AbstractClient.php
+++ b/src/Client/AbstractClient.php
@@ -12,8 +12,12 @@ use BTCPayServer\Http\Response;
 class AbstractClient
 {
 
-    private string $apiKey;
-    private string $baseUrl;
+    /** @var string */
+    private $apiKey;
+    /** @var string */
+    private $baseUrl;
+    /** @var string */
+    private $apiPath = '/api/v1/';
 
     public function __construct(string $baseUrl, string $apiKey)
     {
@@ -23,7 +27,7 @@ class AbstractClient
 
     protected function getBaseUrl(): string
     {
-        return $this->baseUrl;
+        return $this->baseUrl . $this->apiPath;
     }
 
     protected function getApiKey(): string

--- a/src/Client/Invoice.php
+++ b/src/Client/Invoice.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace BTCPayServer\Client;
 
-use BTCPayServer\Http\Client;
+use BTCPayServer\Http\CurlClient;
 use BTCPayServer\Result\PaymentMethod;
 
 class Invoice extends AbstractClient
@@ -12,10 +12,10 @@ class Invoice extends AbstractClient
 
     public function getInvoice(string $storeId, string $invoiceId): \BTCPayServer\Result\Invoice
     {
-        $url = $this->getBaseUrl() . '/api/v1/stores/' . urlencode($storeId) . '/invoices/' . urlencode($invoiceId);
+        $url = $this->getBaseUrl() . 'stores/' . urlencode($storeId) . '/invoices/' . urlencode($invoiceId);
         $headers = $this->getRequestHeaders();
         $method = 'GET';
-        $response = Client::request($method, $url, '', $headers);
+        $response = CurlClient::request($method, $url, $headers);
 
         if ($response->getStatus() === 200) {
             return new \BTCPayServer\Result\Invoice(json_decode($response->getBody(), true));
@@ -32,11 +32,11 @@ class Invoice extends AbstractClient
     public function getPaymentMethods(string $storeId, string $invoiceId): array
     {
         $method = 'GET';
-        $url = $this->getBaseUrl() . '/api/v1/stores/' . urlencode($storeId) . '/invoices/' . urlencode(
+        $url = $this->getBaseUrl() . 'stores/' . urlencode($storeId) . '/invoices/' . urlencode(
                 $invoiceId
             ) . '/payment-methods';
         $headers = $this->getRequestHeaders();
-        $response = Client::request($method, $url, '', $headers);
+        $response = CurlClient::request($method, $url, $headers);
 
         if ($response->getStatus() === 200) {
             $r = [];

--- a/src/Client/Store.php
+++ b/src/Client/Store.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BTCPayServer\Client;
+
+use BTCPayServer\Http\CurlClient;
+
+class Store extends AbstractClient
+{
+  public function getStore($storeId)
+  {
+    $url = $this->getBaseUrl() . 'stores/' . urlencode($storeId);
+    $headers = $this->getRequestHeaders();
+    $method = 'GET';
+    $response = CurlClient::request($method, $url, $headers);
+
+    if ($response->getStatus() === 200) {
+      return new \BTCPayServer\Result\Store(json_decode($response->getBody(), true));
+    } else {
+      throw $this->getExceptionByStatusCode($method, $url, $response);
+    }
+  }
+}

--- a/src/Exception/BTCPayException.php
+++ b/src/Exception/BTCPayException.php
@@ -3,11 +3,11 @@ declare(strict_types=1);
 
 namespace BTCPayServer\Exception;
 
-use BTCPayServer\Http\Response;
+use BTCPayServer\Http\ResponseInterface;
 
 class BTCPayException extends \RuntimeException
 {
-    public function __construct(string $method, string $url, Response $response)
+    public function __construct(string $method, string $url, ResponseInterface $response)
     {
         $message = 'Error during '.$method.' to '.$url.'. Got response ('.$response->getStatus().'): '.$response->getBody();
         parent::__construct($message, $response->getStatus());

--- a/src/Exception/BadRequestException.php
+++ b/src/Exception/BadRequestException.php
@@ -7,5 +7,4 @@ namespace BTCPayServer\Exception;
 class BadRequestException extends BTCPayException
 {
     public const STATUS = 400;
-
 }

--- a/src/Exception/ForbiddenException.php
+++ b/src/Exception/ForbiddenException.php
@@ -6,6 +6,5 @@ namespace BTCPayServer\Exception;
 
 class ForbiddenException extends BTCPayException
 {
-    public const STATUS = 400;
-
+    public const STATUS = 401;
 }

--- a/src/Exception/ForbiddenException.php
+++ b/src/Exception/ForbiddenException.php
@@ -6,5 +6,5 @@ namespace BTCPayServer\Exception;
 
 class ForbiddenException extends BTCPayException
 {
-    public const STATUS = 401;
+    public const STATUS = 403;
 }

--- a/src/Http/ClientInterface.php
+++ b/src/Http/ClientInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BTCPayServer\Http;
+
+interface ClientInterface {
+
+  /**
+   * Sends the HTTP request to API server.
+   *
+   * @param string $method
+   * @param string $url
+   * @param array  $headers
+   * @param string $body
+   *
+   * @return \BTCPayServer\Http\ResponseInterface
+   */
+  public static function request(string $method, string $url, array $headers = [], string $body = ''): ResponseInterface;
+}

--- a/src/Http/CurlClient.php
+++ b/src/Http/CurlClient.php
@@ -30,7 +30,7 @@ class CurlClient implements ClientInterface
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_HEADER, 1);
-        if (!empty($body)) {
+        if ($body !== '') {
           curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
         }
         curl_setopt($ch, CURLOPT_HTTPHEADER, $flatHeaders);

--- a/src/Http/CurlClient.php
+++ b/src/Http/CurlClient.php
@@ -4,17 +4,22 @@ declare(strict_types=1);
 
 namespace BTCPayServer\Http;
 
-class Client
+/**
+ * HTTP Client using cURL to communicate.
+ */
+class CurlClient implements ClientInterface
 {
 
+    /**
+     * @inheritdoc
+     */
     public static function request(
         string $method,
         string $url,
-        string $body = '',
-        array $headers = []
-    ): \BTCPayServer\Http\Response
+        array $headers = [],
+        string $body = ''
+    ): ResponseInterface
     {
-
         $flatHeaders = [];
         foreach ($headers as $key => $value) {
             $flatHeaders[] = $key . ': ' . $value;
@@ -25,7 +30,9 @@ class Client
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_HEADER, 1);
-        curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
+        if (!empty($body)) {
+          curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
+        }
         curl_setopt($ch, CURLOPT_HTTPHEADER, $flatHeaders);
 
         $responseString = curl_exec($ch);

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -4,22 +4,16 @@ declare(strict_types=1);
 
 namespace BTCPayServer\Http;
 
-class Response
+class Response implements ResponseInterface
 {
 
-  /**
-   * @var int
-   */
+  /** @var int */
   private $status;
 
-  /**
-   * @var string
-   */
+  /** @var string */
   private $body;
 
-  /**
-   * @var array
-   */
+  /** @var array */
   private $headers;
 
   public function __construct(int $status, string $body, array $headers)
@@ -29,25 +23,16 @@ class Response
     $this->headers = $headers;
   }
 
-  /**
-   * @return int
-   */
   public function getStatus(): int
   {
     return $this->status;
   }
 
-  /**
-   * @return string
-   */
   public function getBody(): string
   {
     return $this->body;
   }
 
-  /**
-   * @return array
-   */
   public function getHeaders(): array
   {
     return $this->headers;

--- a/src/Http/ResponseInterface.php
+++ b/src/Http/ResponseInterface.php
@@ -12,12 +12,12 @@ interface ResponseInterface {
   public function getStatus(): int;
 
   /**
-   * JSON encoded string.
+   * Response data.
    */
   public function getBody(): string;
 
   /**
-   * HTTP headers of the response.
+   * HTTP headers as an associative array of the response.
    */
   public function getHeaders(): array;
 }

--- a/src/Http/ResponseInterface.php
+++ b/src/Http/ResponseInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BTCPayServer\Http;
+
+interface ResponseInterface {
+
+  /**
+   * HTTP status code.
+   */
+  public function getStatus(): int;
+
+  /**
+   * JSON encoded string.
+   */
+  public function getBody(): string;
+
+  /**
+   * HTTP headers of the response.
+   */
+  public function getHeaders(): array;
+}

--- a/src/Result/AbstractResult.php
+++ b/src/Result/AbstractResult.php
@@ -6,9 +6,8 @@ namespace BTCPayServer\Result;
 
 abstract class AbstractResult
 {
-    /**
-     * @var array
-     */
+
+    /** @var array */
     private $data;
 
     public function __construct(array $data)

--- a/src/Result/Store.php
+++ b/src/Result/Store.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace BTCPayServer\Result;
 
-class PaymentMethod extends AbstractResult
-{
+class Store extends AbstractResult {
 
 }


### PR DESCRIPTION
- interfaces for allowing custom clients/response classes downstream (CurlClient, Response)
- renaming Client -> CurlClient to allow other clients if needed
- added examples/ directory and two examples
- PHP 7.3 compat; class property type hint not supported until PHP 7.4 unfortunately
- CurlClient: on `request()` method moved $body as last param to make it optional
- AbstractClient: simplified handling of basePath to include API path
- added Store client and Result classes